### PR TITLE
Wip 241215

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ $ deno test
 
 Can one touch testing with test_all.bat
 
+### Known Problem
+
+- deno test makes suspicious leak detection on the Engine.
+	but can end process normally, it's indicated a Deno's bug.

--- a/api/logger.js
+++ b/api/logger.js
@@ -3,6 +3,8 @@
 // © 2024 Yggdrasil Leaves, LLC.          //
 //        All rights reserved.            //
 
+import util from './util.js';
+
 // Logger //
 
 // log level 
@@ -18,6 +20,11 @@ const _log_level_lookup=Object.freeze(ll);
 const _default_showable=_log_level_lookup.INFO;
 
 function _default_format(capt,lev,msg){
+
+	switch(typeof msg){
+		case 'function': msg=msg(); break;
+		case 'object': msg=util.inspect(msg); break;
+	}
 
 	var lln=_log_level_names[lev]??('?'+lev+'?');
 	if(capt)capt='{'+capt+'} ';

--- a/api/stmac.js
+++ b/api/stmac.js
@@ -1,0 +1,241 @@
+﻿// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Statemachine //
+
+import engine from './engine.js';
+import hap_global from './happening.js';
+
+function _run(start,states={},opt={}){
+
+	var launcher=opt.launcher??engine;
+	var cur=null;
+
+	var name=opt.name??'YgEs_Statemachine';
+	var happen=opt.happen??hap_global;
+	var user=opt.user??{};
+
+	var state_prev=null;
+	var state_cur=null;
+	var state_next=start;
+
+	var ctrl={
+		name:name+'_Control',
+		User:{},
+		getHappeningManager:()=>happen,
+		getPrevState:()=>state_prev,
+		getCurState:()=>state_cur,
+		getNextState:()=>state_next,
+	}
+
+	var getInfo=(phase)=>{
+		return {
+			name:name,
+			prev:state_prev,
+			cur:state_cur,
+			next:state_next,
+			phase:phase,
+			ctrl:ctrl.User,
+			user:user,
+		}
+	}
+
+	var poll_nop=(user)=>{}
+	var poll_cur=poll_nop;
+
+	var call_start=(user)=>{
+		if(state_next==null){
+			// normal end 
+			cur=null;
+			poll_cur=poll_nop;
+			return;
+		}
+		cur=states[state_next]??null;
+		if(!cur){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'state missing: '+state_next,
+				info:getInfo('selecing'),
+			});
+			poll_cur=poll_nop;
+			return;
+		}
+		state_prev=state_cur;
+		state_cur=state_next;
+		state_next=null;
+		try{
+			if(cur.cb_start)cur.cb_start(ctrl,user);
+			poll_cur=poll_up;
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('cb_start'),
+				err:util.fromError(e),
+			});
+			poll_cur=poll_nop;
+		}
+		// can try extra polling 
+		poll_cur(user);
+	}
+	var poll_up=(user)=>{
+		try{
+			var r=cur.poll_up?cur.poll_up(ctrl,user):true;
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('poll_up'),
+				err:util.fromError(e),
+			});
+			r=false;
+		}
+		if(r==null)return; // continuing 
+		else if(r===false)proc.abort();
+		else if(r===true){
+			try{
+				// normal transition 
+				if(cur.cb_ready)cur.cb_ready(ctrl,user);
+				poll_cur=poll_keep;
+			}
+			catch(e){
+				stmac.happen.happenProp({
+					class:'YgEs_Statemachine_Error',
+					cause:'throw from a callback',
+					info:getInfo('cb_ready'),
+					err:util.fromError(e),
+				});
+				poll_cur=poll_nop;
+			}
+			// can try extra polling 
+			poll_cur(user);
+		}
+		else{
+			// interruption 
+			state_next=r.toString();
+			call_end(user);
+		}
+	}
+	var poll_keep=(user)=>{
+		try{
+			var r=cur.poll_keep?cur.poll_keep(ctrl,user):true;
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('poll_keep'),
+				err:util.fromError(e),
+			});
+			r=false;
+		}
+		if(r==null)return; // continuing 
+		else if(r===false)proc.abort();
+		else if(r===true){
+			// normal end 
+			state_next=null;
+			call_stop(user);
+		}
+		else{
+			// normal transition 
+			state_next=r.toString();
+			call_stop(user);
+		}
+	}
+	var call_stop=(user)=>{
+		try{
+			if(cur.cb_stop)cur.cb_stop(ctrl,user);
+			poll_cur=poll_down;
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('cb_stop'),
+				err:util.fromError(e),
+			});
+			poll_cur=poll_nop;
+		}
+		// can try extra polling 
+		poll_cur(user);
+	}
+	var poll_down=(user)=>{
+		try{
+			var r=cur.poll_down?cur.poll_down(ctrl,user):true;
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('poll_down'),
+				err:util.fromError(e),
+			});
+			r=false;
+		}
+		if(r==null)return; // continuing 
+		else if(r===false)proc.abort();
+		else if(r===true){
+			// normal transition 
+			call_end(user);
+		}
+		else{
+			// interruption 
+			state_next=r.toString();
+			call_end(user);
+		}
+	}
+	var call_end=(user)=>{
+		try{
+			if(cur.cb_end)cur.cb_end(ctrl,user);
+			call_start(user);
+		}
+		catch(e){
+			stmac.happen.happenProp({
+				class:'YgEs_Statemachine_Error',
+				cause:'throw from a callback',
+				info:getInfo('cb_end'),
+				err:util.fromError(e),
+			});
+			poll_cur=poll_nop;
+		}
+	}
+
+	var stmac={
+		name:name,
+		happen:happen,
+		user:user,
+
+		cb_start:(user)=>{
+			call_start(user);
+		},
+		cb_poll:(user)=>{
+			poll_cur(user);
+			return !!cur;
+		},
+		cb_done:opt.cb_done??'',
+		cb_abort:opt.cb_abort??'',
+	}
+
+	var proc=launcher.launch(stmac);
+	ctrl.isStarted=proc.isStarted;
+	ctrl.isFinished=proc.isFinished;
+	ctrl.isAborted=proc.isAborted;
+	ctrl.isEnd=proc.isEnd;
+	ctrl.abort=proc.abort;
+	ctrl.sync=proc.sync;
+	ctrl.toPromise=proc.toPromise;
+	return ctrl;
+}
+
+var mif={
+	name:'YgEs_StateMachineContainer',
+	User:{},
+
+	run:_run,
+}
+
+export default mif;

--- a/api/timing.js
+++ b/api/timing.js
@@ -1,0 +1,146 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Basic Timing Features //
+
+var mif={
+	name:'YgEs_Timing',
+	User:{},
+
+	fromPromise:(promise,cb_ok=null,cb_ng=null)=>{
+		new Promise(async (ok,ng)=>{
+			try{
+				ok(await promise);
+			}
+			catch(e){
+				ng(e);
+			}
+		}).then((r)=>{
+			if(cb_ok)cb_ok(r);
+			return r;
+		}).catch((e)=>{
+			if(cb_ng)cb_ng(e);
+			else throw e;
+		});
+	},
+	toPromise:(cb_proc,cb_done=null,cb_fail=null)=>{
+		var p=new Promise((ok,ng)=>{
+			cb_proc(ok,ng);
+		}).then((r)=>{
+			if(cb_done)cb_done(r);
+			return r;
+		}).catch((e)=>{
+			if(cb_fail)cb_fail(e);
+			else throw e;
+		});
+		return p;
+	},
+
+	delay:(ms,cb_done,cb_cancel=null)=>{
+
+		var h=null;
+		if(!cb_done)return ()=>{
+			if(cb_cancel)cb_cancel();
+		};
+
+		h=setTimeout(()=>{
+			h=null;
+			cb_done();
+		},ms);
+
+		// canceller 
+		return async ()=>{
+			if(h==null)return;
+			clearTimeout(h);
+			h=null;
+			if(cb_cancel)cb_cancel();
+		}
+	},
+
+	poll:(ms,cb_poll,cb_abort=null)=>{
+
+		if(!cb_poll)return ()=>{
+			if(cb_abort)cb_abort();
+		};
+
+		var cancel=null;
+		var next=()=>{
+			cancel=mif.delay(ms,()=>{
+				cb_poll();
+				if(!cancel)return;
+				cancel=null;
+				next();
+			});
+		}
+		next();
+		return ()=>{
+			if(!cancel)return;
+			cancel();
+			cancel=null;
+			if(cb_abort)cb_abort();
+		}
+	},
+
+	sync:(ms,cb_chk,cb_done,cb_abort=null)=>{
+
+		if(!cb_chk)return ()=>{};
+		if(!cb_done)return ()=>{};
+
+		var cancel=null;
+		if(cb_chk()){
+			cb_done();
+			return ()=>{};
+		}
+
+		cancel=mif.poll(ms,()=>{
+			if(!cb_chk())return;
+			if(cancel){
+				cancel();
+				cancel=null;
+			}
+			cb_done();
+		});
+
+		return ()=>{
+			if(!cancel)return;
+			cancel();
+			cancel=null;
+			cb_abort();
+		}
+	},
+
+	delayKit:(ms,cb_done=null,cb_cancel=null)=>{
+		var kit={}
+		kit.promise=()=>mif.toPromise((ok,ng)=>{
+			kit.cancel=mif.delay(ms,
+			()=>{
+				if(cb_done)cb_done();
+				ok();
+			},()=>{
+				if(cb_cancel)cb_cancel();
+				ng(new Error('Delay Cancelled'));
+			});
+		});
+		return kit;
+	},
+	syncKit:(ms,cb_chk,cb_done=null,cb_abort=null)=>{
+		var kit={}
+		kit.promise=()=>mif.toPromise((ok,ng)=>{
+			kit.cancel=mif.sync(ms,cb_chk,
+			()=>{
+				if(cb_done)ok(cb_done());
+				else ok();
+			},()=>{
+				if(cb_abort)cb_abort();
+				ng(new Error('Sync Aborted'));
+			});
+			if(!cb_chk)ng(new Error('No Conditions for Sync'));
+		});
+		return kit;
+	},
+
+}
+
+export default mif;

--- a/api/unittest.js
+++ b/api/unittest.js
@@ -10,6 +10,7 @@ import {
 } from "https://deno.land/std@0.65.0/testing/asserts.ts";
 
 import util from './util.js';
+import hap_global from './happening.js';
 
 function _cpmsg(msg,v1,op,v2){
 	if(!msg)msg='Test Mismatch:';
@@ -35,19 +36,30 @@ export default {
 		// unselected tests are ignored. 
 		// (use insted of Deno.test({only:true}) to suppress redundant log) 
 		var puf=false;
-		for(var t of scn){
+		for(let t of scn){
 			if(!t.pickup)continue;
 			puf=true;
 			break;
 		}
 
-		for(var t of scn){
+		for(let t of scn){
 			if(puf && !t.pickup)continue;
 			if(t.filter!==undefined && !t.filter)continue;
 			Deno.test({
 				name: t.title,
-				fn: t.proc,
+				fn: async ()=>{
+					await t.proc();
+//					await new Promise((ok)=>{setTimeout(ok,1000);});
+				},
 			});
 		}
+
+		Deno.test({
+			name: 'Final Cleanup',
+			fn: ()=>{
+				hap_global.cleanup();
+				if(!hap_global.isCleaned())throw util.inspect(hap_global.getInfo());
+			},
+		});
 	},
 };

--- a/api/util.js
+++ b/api/util.js
@@ -144,6 +144,18 @@ var mif={
 		return JSON.stringify(val);
 	},
 
+	fromError:(err)=>{
+		return {
+			name:err.name,
+			msg:err.message,
+			file:err.fileName,
+			line:err.lineNumber,
+			col:err.columnNumber,
+			stack:err.stack,
+			src:err,
+		}
+	},
+
 	safeStepIter:(bgn,end,step,cbiter)=>{
 
 		var cnt=bgn;

--- a/example/001-logger.js
+++ b/example/001-logger.js
@@ -29,6 +29,14 @@ log.put(log.LEVEL.INFO,'INFO Log too');
 // overlevel logs are always suppressed 
 log.put(log.LEVEL.NEVER,'NEVER Log');
 
+// can output an object directly, without JSON.stringify(), more correct   
+var obj={a:1,b:NaN,c:Infinity,d:[undefined]}
+log.debug(JSON.stringify(obj));
+log.debug(obj);
+
+// can postpone creating message to suppress CPU cost
+log.debug(()=>'deferred message creation: '+Math.log10(1000));
+
 // create local log instance 
 var ll1=log.createLocal('Local',log.LEVEL.TRACE);
 

--- a/example/015-timing.js
+++ b/example/015-timing.js
@@ -1,0 +1,135 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Examples: Basic Timing Features //
+
+import eng from '../api/engine.js';
+import log from '../api/logger.js';
+import timing from '../api/timing.js';
+
+// delaying 
+timing.delay(500,()=>{
+	log.info('Delayed');
+});
+
+// cancellable delay 
+var cancel1=timing.delay(10000,()=>{
+	log.info('Cannot Step It');
+});
+timing.delay(800,()=>{
+	cancel1();
+	log.info('Delaying Cancelled');
+});
+
+// polling 
+var count2=0;
+var cancel2=timing.poll(100,()=>{
+	log.info('Polling: '+(++count2));
+});
+timing.delay(1000,()=>{
+	cancel2();
+	log.info('Polling Cancelled');
+});
+
+// synchronization
+timing.sync(50,()=>{
+	return count2>4;
+},()=>{
+	log.info('Sync1 Done');
+},()=>{
+	log.info('Sync1 Cancelled');
+});
+
+var cancel3=timing.sync(50,()=>{
+	return count2>4;
+},()=>{
+	log.info('Sync2 Done');
+},()=>{
+	log.info('Sync2 Cancelled');
+});
+timing.delay(300,()=>{
+	cancel3();
+});
+
+(async ()=>{
+	// cancellable delay on Promise 
+	var dk=timing.delayKit(500);
+	await dk.promise();
+	log.info('delayed on Promise');
+
+	try{
+		dk=timing.delayKit(500);
+		timing.delay(350,()=>{dk.cancel();});
+		await dk.promise();
+		log.info('delayed on Promise');
+	}
+	catch(e){
+		log.warn(e.message);
+	}
+
+	// cancellable sync on Promise 
+	var go=false;
+	var sk=timing.syncKit(50,()=>{return go;});
+	timing.delay(100,()=>{go=true;});
+	await sk.promise();
+	log.info('synchronized on Promise');
+
+	try{
+		go=false;
+		sk=timing.syncKit(50,()=>{return go;});
+		timing.delay(100,()=>{sk.cancel();});
+		await sk.promise();
+	}
+	catch(e){
+		log.warn(e.message);
+	}
+
+	// create Promises 
+	log.info(await timing.toPromise((ok,ng)=>{
+		ok('OK via Promise');
+	}));
+
+	await timing.toPromise((ok,ng)=>{
+		ok('OK via Callback');
+	},(res)=>{
+		log.info(res);
+	});
+
+	try{
+		log.info(await timing.toPromise((ok,ng)=>{
+			ng('NG via Promise');
+		}));
+	}
+	catch(err){
+		log.warn(err);
+	}
+
+	await timing.toPromise((ok,ng)=>{
+		ng('NG via Promise');
+	},(res)=>{
+		log.info('OK via Callback');
+	},(err)=>{
+		log.warn('NG via Callback');
+	});
+
+	// eazy Promise running
+	timing.fromPromise(
+		timing.toPromise((ok,ng)=>{ok();}),
+		(res)=>{
+			log.info('OK to Callback');
+		}
+	);
+	timing.fromPromise(
+		timing.toPromise((ok,ng)=>{ng();}),
+		(res)=>{
+			log.info('OK to Callback');
+		},
+		(err)=>{
+			log.warn('NG to Callback');
+		}
+	);
+
+
+})();

--- a/example/025-statemachine.js
+++ b/example/025-statemachine.js
@@ -1,0 +1,154 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Examples: Statemachine //
+
+import eng from '../api/engine.js';
+import stmac from '../api/stmac.js';
+import timing from '../api/timing.js';
+import log from '../api/logger.js';
+
+var states={
+	'StateA':{
+		cb_start:(ctx,user)=>{
+			log.info(ctx.getCurState()+' start');
+		},
+		poll_up:(ctx,user)=>{
+			// goto next phase 
+			return (++user.count<10)?null:true;
+		},
+		cb_ready:(ctx,user)=>{
+			log.info(ctx.getCurState()+' ready');
+		},
+		poll_keep:(ctx,user)=>{
+			// goto StateB 
+			return (++user.count<20)?null:'StateB';
+		},
+		cb_stop:(ctx,user)=>{
+			log.info(ctx.getCurState()+' stop');
+		},
+		poll_down:(ctx,user)=>{
+			// goto next state 
+			return (++user.count<30)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			log.info(ctx.getCurState()+' end');
+		},
+	},
+	'StateB':{
+		cb_start:(ctx,user)=>{
+			log.info(ctx.getCurState()+' start');
+		},
+		poll_up:(ctx,user)=>{
+			// goto next phase 
+			return (++user.count<40)?null:true;
+		},
+		cb_ready:(ctx,user)=>{
+			log.info(ctx.getCurState()+' ready');
+		},
+		poll_keep:(ctx,user)=>{
+			// goto end
+			return (++user.count<50)?null:true;
+		},
+		cb_stop:(ctx,user)=>{
+			log.info(ctx.getCurState()+' stop');
+		},
+		poll_down:(ctx,user)=>{
+			// next state is interrupted by StateC 
+			return (++user.count<60)?null:'StateC';
+		},
+		cb_end:(ctx,user)=>{
+			log.info(ctx.getCurState()+' end');
+		},
+	},
+	'StateC':{
+		cb_start:(ctx,user)=>{
+			log.info(ctx.getCurState()+' start');
+		},
+		poll_up:(ctx,user)=>{
+			// next phase is interrupted by StateD 
+			// and stop this state now 
+			return (++user.count<70)?null:'StateD';
+		},
+		cb_ready:(ctx,user)=>{
+			log.info(ctx.getCurState()+' ready');
+		},
+		poll_keep:(ctx,user)=>{
+			// skipped by interruption 
+			return (++user.count<80)?null:true;
+		},
+		cb_stop:(ctx,user)=>{
+			log.info(ctx.getCurState()+' stop');
+		},
+		poll_down:(ctx,user)=>{
+			// goto next state 
+			return (++user.count<90)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			log.info(ctx.getCurState()+' end');
+		},
+	},
+	'StateD':{
+		cb_start:(ctx,user)=>{
+			log.info(ctx.getCurState()+' start');
+		},
+		poll_up:(ctx,user)=>{
+			// goto next phase 
+			return (++user.count<100)?null:true;
+		},
+		cb_ready:(ctx,user)=>{
+			log.info(ctx.getCurState()+' ready');
+		},
+		poll_keep:(ctx,user)=>{
+			// goto end 
+			return (++user.count<110)?null:true;
+		},
+		cb_stop:(ctx,user)=>{
+			log.info(ctx.getCurState()+' stop');
+		},
+		poll_down:(ctx,user)=>{
+			// goto next state (is end)
+			return (++user.count<120)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			log.info(ctx.getCurState()+' end');
+		},
+	},
+}
+
+// start the Engine 
+eng.start();
+
+var opt1={
+	launcher:eng.createLauncher(),
+	user:{name:'Test1',count:1}, // share in states 
+	cb_done:(user)=>{
+		log.info(user.name+' done');
+
+		// run from StateB 
+		// and abort after 200msec 
+		var ctrl=stmac.run('StateB',states,opt2);
+		timing.delay(200,()=>{ctrl.abort();});
+	},
+	cb_abort:(user)=>{
+		log.info(user.name+' abort');
+	},
+}
+var opt2={
+	launcher:eng.createLauncher(),
+	user:{name:'Test2',count:1}, // share in states 
+	cb_done:(user)=>{
+		log.info(user.name+' done');
+	},
+	cb_abort:(user)=>{
+		log.info(user.name+' abort');
+	},
+}
+
+stmac.run('StateA',states,opt1);
+
+opt1.launcher.sync((dmy)=>{
+	eng.shutdown();
+});

--- a/test/engine/launcher.js
+++ b/test/engine/launcher.js
@@ -7,6 +7,8 @@
 
 import test from '../../api/unittest.js';
 import eng from '../../api/engine.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
 
 const PROCS=100;
 const LIMIT=30;
@@ -16,13 +18,20 @@ var count_start=0;
 var count_done=0;
 var count_abort=0;
 
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
 eng.start();
 
 var scenaria=[
 	{
 		title:'Launcher',
 		proc:async ()=>{
-			var lnc=eng.createLauncher('test launcher');
+			var lnc=eng.createLauncher({
+				name:'test launcher',
+				happen:hap_local,
+			});
 			lnc.Limit=0;
 			test.chk_strict(0,lnc.countActive(),'empty launcher');
 			test.chk_strict(0,lnc.countHeld(),'empty launcher');

--- a/test/engine/rootproc.js
+++ b/test/engine/rootproc.js
@@ -7,10 +7,16 @@
 
 import test from '../../api/unittest.js';
 import eng from '../../api/engine.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
 
 var count_start=0;
 var count_done=0;
 var count_abort=0;
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
 
 eng.start();
 
@@ -19,6 +25,7 @@ var scenaria=[
 		title:'Root Async Proc',
 		proc:async ()=>{
 			var proc=eng.launch({
+				happen:hap_local,
 				cb_start:(user)=>{
 					user.lock=true;
 					++count_start;

--- a/test/statemachine/1state.js
+++ b/test/statemachine/1state.js
@@ -1,0 +1,78 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// 1 State Test //
+
+import test from '../../api/unittest.js';
+import eng from '../../api/engine.js';
+import stmac from '../../api/stmac.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
+var states={
+	'Test':{
+		cb_start:(ctx,user)=>{
+			test.chk_strict(++user.count,2,'cb_start called illegular');
+		},
+		poll_up:(ctx,user)=>{
+			test.chk_great(++user.count,2,'poll_up called illegular');
+			test.chk_less_eq(user.count,10,'poll_up called illegular');
+			return (user.count<10)?null:true;
+		},
+		cb_ready:(ctx,user)=>{
+			test.chk_strict(++user.count,11,'cb_ready called illegular');
+		},
+		poll_keep:(ctx,user)=>{
+			test.chk_great(++user.count,11,'poll_keep called illegular');
+			test.chk_less_eq(user.count,20,'poll_keep called illegular');
+			return (user.count<20)?null:true;
+		},
+		cb_stop:(ctx,user)=>{
+			test.chk_strict(++user.count,21,'cb_stop called illegular');
+		},
+		poll_down:(ctx,user)=>{
+			test.chk_great(++user.count,21,'poll_down called illegular');
+			test.chk_less_eq(user.count,30,'poll_down called illegular');
+			return (user.count<30)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,31,'cb_end called illegular');
+		},
+	},
+}
+
+eng.start();
+
+var opt={
+	launcher:eng.createLauncher(),
+	happen:hap_local,
+	user:{count:1}, // share in states 
+	cb_done:(user)=>{
+		test.chk_strict(++user.count,32,'cb_done called illegular');
+	},
+	cb_abort:(user)=>{
+		test.never('states abend');
+	},
+}
+
+var scenaria=[
+	{
+		title:'1 State Running',
+		proc:async ()=>{
+			// run with undefined state 
+			// abort soon 
+			stmac.run('Test',states,opt);
+
+			await opt.launcher.toPromise();
+			eng.shutdown();
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/statemachine/2state.js
+++ b/test/statemachine/2state.js
@@ -1,0 +1,70 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// 2 States Test //
+
+import test from '../../api/unittest.js';
+import eng from '../../api/engine.js';
+import stmac from '../../api/stmac.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
+var states={
+	'Test1':{
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,10,'poll_keep called illegular');
+			return (user.count<10)?null:'Test2';
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,11,'cb_end called illegular');
+		},
+	},
+	'Test2':{
+		cb_start:(ctx,user)=>{
+			test.chk_strict(++user.count,12,'cb_start called illegular');
+		},
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,20,'poll_keep called illegular');
+			return (user.count<20)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,21,'cb_end called illegular');
+		},
+	},
+}
+
+eng.start();
+
+var opt={
+	launcher:eng.createLauncher(),
+	happen:hap_local,
+	user:{count:1}, // share in states 
+	cb_done:(user)=>{
+		test.chk_strict(++user.count,22,'cb_done called illegular');
+	},
+	cb_abort:(user)=>{
+		test.never('states abend');
+	},
+}
+
+var scenaria=[
+	{
+		title:'2 States Running',
+		proc:async ()=>{
+			// run with undefined state 
+			// abort soon 
+			stmac.run('Test1',states,opt);
+
+			await opt.launcher.toPromise();
+			eng.shutdown();
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/statemachine/empty.js
+++ b/test/statemachine/empty.js
@@ -1,0 +1,49 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Empty State Test //
+
+import test from '../../api/unittest.js';
+import eng from '../../api/engine.js';
+import stmac from '../../api/stmac.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
+// empty states
+var states={
+}
+
+eng.start();
+
+var opt={
+	launcher:eng.createLauncher(),
+	happen:hap_local,
+	cb_done:(user)=>{
+		// OK 
+	},
+	cb_abort:(user)=>{
+		test.never('states abend');
+	},
+}
+
+var scenaria=[
+	{
+		title:'Empty Running',
+		proc:async ()=>{
+			// run with undefined state 
+			// abort soon 
+			stmac.run(null,states,opt);
+
+			await opt.launcher.toPromise();
+			eng.shutdown();
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/statemachine/int_down.js
+++ b/test/statemachine/int_down.js
@@ -1,0 +1,78 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// State Interruption from Down //
+
+import test from '../../api/unittest.js';
+import eng from '../../api/engine.js';
+import stmac from '../../api/stmac.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
+var states={
+	'Test1':{
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,10,'poll_keep called illegular');
+			return (user.count<10)?null:'Test2A';
+		},
+		poll_down:(ctx,user)=>{
+			return 'Test2B';
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,11,'cb_end called illegular');
+		},
+	},
+	'Test2A':{
+		cb_start:(ctx,user)=>{
+			test.never("don't step it");
+		},
+	},
+	'Test2B':{
+		cb_start:(ctx,user)=>{
+			test.chk_strict(++user.count,12,'cb_start called illegular');
+		},
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,20,'poll_keep called illegular');
+			return (user.count<20)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,21,'cb_end called illegular');
+		},
+	},
+}
+
+eng.start();
+
+var opt={
+	launcher:eng.createLauncher(),
+	happen:hap_local,
+	user:{count:1}, // share in states 
+	cb_done:(user)=>{
+		test.chk_strict(++user.count,22,'cb_done called illegular');
+	},
+	cb_abort:(user)=>{
+		test.never('states abend');
+	},
+}
+
+var scenaria=[
+	{
+		title:'Interruption from Down',
+		proc:async ()=>{
+			// run with undefined state 
+			// abort soon 
+			stmac.run('Test1',states,opt);
+
+			await opt.launcher.toPromise();
+			eng.shutdown();
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/statemachine/int_up.js
+++ b/test/statemachine/int_up.js
@@ -1,0 +1,89 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// State Interruption from Up //
+
+import test from '../../api/unittest.js';
+import eng from '../../api/engine.js';
+import stmac from '../../api/stmac.js';
+import log from '../../api/logger.js';
+import hap_global from '../../api/happening.js';
+
+var hap_local=hap_global.createLocal({
+	happen:(hap)=>{log.fatal(hap.GetProp());},
+});
+
+var states={
+	'Test1':{
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,10,'poll_keep called illegular');
+			return (user.count<10)?null:'Test2A';
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,11,'cb_end called illegular');
+		},
+	},
+	'Test2A':{
+		cb_start:(ctx,user)=>{
+			test.chk_strict(++user.count,12,'cb_start called illegular');
+		},
+		poll_up:(ctx,user)=>{
+			return 'Test2B';
+		},
+		poll_keep:(ctx,user)=>{
+			test.never("don't step it");
+			return false;
+		},
+		poll_down:(ctx,user)=>{
+			test.never("don't step it");
+			return false;
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,13,'cb_end called illegular');
+		},
+	},
+	'Test2B':{
+		cb_start:(ctx,user)=>{
+			test.chk_strict(++user.count,14,'cb_start called illegular');
+		},
+		poll_keep:(ctx,user)=>{
+			test.chk_less_eq(++user.count,20,'poll_keep called illegular');
+			return (user.count<20)?null:true;
+		},
+		cb_end:(ctx,user)=>{
+			test.chk_strict(++user.count,21,'cb_end called illegular');
+		},
+	},
+}
+
+eng.start();
+
+var opt={
+	launcher:eng.createLauncher(),
+	happen:hap_local,
+	user:{count:1}, // share in states 
+	cb_done:(user)=>{
+		test.chk_strict(++user.count,22,'cb_done called illegular');
+	},
+	cb_abort:(user)=>{
+		test.never('states abend');
+	},
+}
+
+var scenaria=[
+	{
+		title:'Interruption from Up',
+		proc:async ()=>{
+			// run with undefined state 
+			// abort soon 
+			stmac.run('Test1',states,opt);
+
+			await opt.launcher.toPromise();
+			eng.shutdown();
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/timing/delay.js
+++ b/test/timing/delay.js
@@ -1,0 +1,41 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Delay Test //
+
+import test from '../../api/unittest.js';
+import timing from '../../api/timing.js';
+
+const interval=100;
+
+var scenaria=[
+	{
+		title:'Delay',
+		proc:async ()=>{
+			var t1=Date.now();
+			await new Promise((ok,ng)=>{
+				timing.delay(interval,()=>{
+					var dt=Date.now()-t1;
+					test.chk_great(dt,interval-(interval>>3));
+					ok();
+				});
+			});
+		},
+	},
+	{
+		title:'Cancel Delay',
+		proc:async ()=>{
+			await new Promise((ok,ng)=>{
+				var cancel=timing.delay(interval,()=>{
+					test.never('not cancelled');
+				});
+				cancel();
+				ok();
+			});
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/timing/polling.js
+++ b/test/timing/polling.js
@@ -1,0 +1,34 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Polling Test //
+
+import test from '../../api/unittest.js';
+import timing from '../../api/timing.js';
+
+const interval=50;
+var count=0;
+
+var scenaria=[
+	{
+		title:'Polling',
+		proc:async ()=>{
+			var t1=Date.now();
+			await new Promise((ok,ng)=>{
+				var cancel=timing.poll(interval,()=>{
+					if(++count>=10){
+						cancel();
+						ok();
+					}
+				});
+			});
+			var dt=Date.now()-t1;
+			test.chk_great(dt,interval*9);
+			test.chk_strict(count,10);
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test/timing/sync.js
+++ b/test/timing/sync.js
@@ -1,0 +1,48 @@
+// † Yggdrasil Essense for JavaScript † //
+// ====================================== //
+// © 2024 Yggdrasil Leaves, LLC.          //
+//        All rights reserved.            //
+
+// Resyncronize Test //
+
+import test from '../../api/unittest.js';
+import timing from '../../api/timing.js';
+
+const interval=50;
+var count=0;
+
+var scenaria=[
+	{
+		title:'Sync',
+		proc:async ()=>{
+			var t1=Date.now();
+			await new Promise((ok,ng)=>{
+				var cancel=timing.sync(interval,()=>{
+					return ++count>=10;
+				},
+				()=>{ok();},
+				()=>{ng();});
+			});
+			var dt=Date.now()-t1;
+			test.chk_great(dt,interval*9);
+			test.chk_strict(count,10);
+		},
+	},
+	{
+		title:'Abort Sync',
+		proc:async ()=>{
+			await new Promise((ok,ng)=>{
+				var cancel=timing.sync(interval,()=>{
+					return ++count>=20;
+				},
+				()=>{ng();},
+				()=>{ok();});
+
+				timing.delay(interval*5,()=>{cancel();});
+				test.chk_less(count,16);
+			});
+		},
+	},
+]
+
+test.run(scenaria);

--- a/test_all.bat
+++ b/test_all.bat
@@ -1,5 +1,5 @@
 cd /d %~dp0
 if exist _setpath.bat call _setpath.bat
 cd test
-deno test **/*
+deno test --trace-leaks **/*
 pause


### PR DESCRIPTION
close #26 

## Timing

単純な非同期処理向け。  
セオリー通り async~await でのコーディングを想定しつつ、  
Promise特有の煩雑な異常系記述をひとつのコールバックにまとめることで  
よく起こりがちなUnhandledバグを防ぐ。    
また、非Promiseコールバック方式との相互変換にも対応する。  

## Engine

非同期処理を一元管理することで  

- 一括完了待ち
- 一括強制終了
- 同時実行数制限

といった機能を提供する。

## Statemachine

状態遷移のある機能の記述用。  

## Worker

状態遷移を持つ機能の共通部で、非同期のセットアップ,シャットダウン,  
依存関係解決,異常管理といった機能をもつ。  

## Deno 版特有の問題点

Engine の最適化を進めたあたりから、deno test が通らなくなっています。  
```
error: Leaks detected:
  - A timer was started before the test, but completed during the test. Intervals and timers should not complete in a test if they were not started in that test. This is often caused by not calling `clearTimeout`. The operation was started here:
```
…とかいわれましても、clearTimeout() はちゃんと通ってるし、プロセス終了も正常にできるし、特に問題なし。    
他にも問題点があったりするので、今後はNode版をメインの動作確認対象とし、Deno版はついで程度の扱いとします。  
