### PR TITLE
FS.Glob をDeno用に書き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,3 @@ Access by your web browser.
 ```
 $ rm server_running
 ```
-
-
-## Known Problem
-
-- in version 2.1.4, File.stat() not work.
-	- 2.0.6 can work.


### PR DESCRIPTION
close #36 

出力形式をNode.js版に合わせているため無駄は多いが、  
example/100-http_server.js が動作するようになったので、これでよしとする。  

注意点として、Node.js版と違い . で始まる名前も結果に含まれる。  
